### PR TITLE
Add a generic test-runner.

### DIFF
--- a/loads.js/index.js
+++ b/loads.js/index.js
@@ -2,22 +2,9 @@
 
 var zmq = require('zmq');
 
-exports = module.exports = LoadsSocket;
-
-// Default configuration for a LoadsSocket is taken from the environment.
-//
-var defaults = exports.defaults = {
-  ZMQ_RECEIVER: 'ipc:///tmp/loads-agent-receiver.ipc',
-  AGENT_ID: '0',
-  RUN_ID: '0',
-  STATUS: '1,1,1,1'
-};
-for (var k in defaults) {
-  if (defaults.hasOwnProperty(k)) {
-    if (process.env.hasOwnProperty("LOADS_" + k)) {
-      defaults[k] = process.env["LOADS_" + k];
-    }
-  }
+exports = module.exports = {
+  LoadsSocket: LoadsSocket,
+  getOptionsFromEnviron: getOptionsFromEnviron
 }
 
 
@@ -25,10 +12,10 @@ for (var k in defaults) {
 //
 function LoadsSocket(options) {
     if (!options) { options = {}; }
-    this.receiver = options.ZMQ_RECEIVER || defaults.ZMQ_RECEIVER;
-    this.agentId = options.AGENT_ID || defaults.AGENT_ID;
-    this.runId = options.RUN_ID || defaults.RUN_ID;
-    this.loadsStatus = (options.STATUS || defaults.STATUS).split(',');
+    this.receiver = options.receiver;
+    this.agentId = options.agentId;
+    this.runId = options.runId;
+    this.loadsStatus = options.loadsStatus.split(',');
     this.initializeSocket();
 }
 
@@ -52,7 +39,7 @@ LoadsSocket.prototype.send = function(type, data, forceSend){
       data_type: type,
       agent_id: this.agentId,
       run_id: this.runId,
-      loads_status: this.loadsStatus
+      loads_status: this.status
     };
 
     if (data !== undefined) {
@@ -70,3 +57,28 @@ LoadsSocket.prototype.close = function(){
     this.socket.close();
     this.context.close();
 };
+
+
+// Read default configuration for LoadsSocket out of environ vars.
+//
+function getOptionsFromEnviron(env) {
+  if (typeof env === "undefined") env = process.env;
+  var options = {
+    agentId: "0",
+    runId: "0",
+    loadsStatus: "1,1,1,1"
+  };
+  if (env.hasOwnProperty("LOADS_ZMQ_RECEIVER")) {
+    options.receiver = env.LOADS_ZMQ_RECEIVER;
+  }
+  if (env.hasOwnProperty("LOADS_AGENT_ID")) {
+    options.agentId = env.LOADS_AGENT_ID;
+  }
+  if (env.hasOwnProperty("LOADS_RUN_ID")) {
+    options.runId = env.LOADS_RUN_ID;
+  }
+  if (env.hasOwnProperty("LOADS_STATUS")) {
+    options.status = env.LOADS_STATUS;
+  }
+  return options;
+}

--- a/loads.js/index.js
+++ b/loads.js/index.js
@@ -4,15 +4,31 @@ var zmq = require('zmq');
 
 exports = module.exports = LoadsSocket;
 
+// Default configuration for a LoadsSocket is taken from the environment.
+//
+var defaults = exports.defaults = {
+  ZMQ_RECEIVER: 'ipc:///tmp/loads-agent-receiver.ipc',
+  AGENT_ID: '0',
+  RUN_ID: '0',
+  STATUS: '1,1,1,1'
+};
+for (var k in defaults) {
+  if (defaults.hasOwnProperty(k)) {
+    if (process.env.hasOwnProperty("LOADS_" + k)) {
+      defaults[k] = process.env["LOADS_" + k];
+    }
+  }
+}
 
-function LoadsSocket(receiver, agentId, runId, loadsStatus) {
-    this.receiver = receiver;
-    this.agentId = agentId;
-    this.runId = runId;
 
-    loadsStatus = loadsStatus || '1,1,1,1';
-    this.loadsStatus = loadsStatus.split(',');
-
+// An object for sending messages back to loads.
+//
+function LoadsSocket(options) {
+    if (!options) { options = {}; }
+    this.receiver = options.ZMQ_RECEIVER || defaults.ZMQ_RECEIVER;
+    this.agentId = options.AGENT_ID || defaults.AGENT_ID;
+    this.runId = options.RUN_ID || defaults.RUN_ID;
+    this.loadsStatus = (options.STATUS || defaults.STATUS).split(',');
     this.initializeSocket();
 }
 

--- a/loads.js/runner.js
+++ b/loads.js/runner.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+// A simple loadtest runner, compatible with the "loads" tool:
+//
+//    http://loads.readthedocs.org/
+//
+
+const zmq = require('zmq');
+const LoadsSocket = require('./index.js');
+
+exports = module.exports = run;
+
+function run(tests, options, cb) {
+  if (typeof tests === 'string') {
+    tests = require(tests);
+  }
+  if (typeof options === 'function' && !cb) {
+   cb = options;
+   options = {};
+  }
+  var sock = new LoadsSocket(options);
+
+  // We'll run each callable property of the tests object in turn.
+  var testnames = Object.keys(tests);
+
+  // Callback that runs the next pending test.
+  function doNextTest(cb) {
+
+    // Find the next property that's actually a function.
+    // When we run out of names, shift() will return undefined.
+    var testname = testnames.shift();
+    while (testname && typeof tests[testname] !== 'function') {
+      testname = testnames.shift();
+    }
+    if (typeof testname === 'undefined') return cb(null);
+
+    // Run the test, passing it a callback that also lets
+    // it access the LoadsSocket object.
+    sock.send('startTest', {test: testname});
+    var testcb = function(err) {
+      if (err) {
+        var exc_info = ["JSError", JSON.stringify(err), ""];
+        sock.send('addFailure', {test: testname, exc_info: exc_info});
+      } else {
+        sock.send('addSuccess', {test: testname});
+      }
+      sock.send('stopTest', {test: testname});
+      process.nextTick(function() {
+        return cb(null);
+      });
+    }
+    testcb.socket = sock;
+    tests[testname](testcb);
+  }
+
+  // Loop over all tests, running each in turn.
+  function doRemainingTests(err) {
+    if (err) { sock.close(); return cb(err); }
+    if (testnames.length == 0) { sock.close(); return cb(null); }
+    doNextTest(doRemainingTests);
+  };
+  doRemainingTests();
+}
+
+
+// When executed as a script, run tests on module given in command-line args.
+// This makes it possible to run this directly as a loads external runner.
+if (require.main === module) {
+  process.title = 'loads.runener';
+  run(process.argv[2], function(err) {
+    process.exit(err ? 1 : 0);
+  });
+}

--- a/mocha-loads/index.js
+++ b/mocha-loads/index.js
@@ -12,11 +12,7 @@ function Loads(runner) {
                 + 'to use the loads reporter.');
     return;
   }
-  var agentId = process.env.LOADS_AGENT_ID || 'ohyeah';
-  var loadsStatus = process.env.LOADS_STATUS || '1,1,1,1';
-  var runId = process.env.LOADS_RUN_ID;
-
-  var socket = new LoadsSocket(address, agentId, runId, loadsStatus);
+  var socket = new LoadsSocket();
 
   runner.on('test', function(test){
     socket.send('startTest', {test: escape(test.title)});

--- a/mocha-loads/index.js
+++ b/mocha-loads/index.js
@@ -1,18 +1,18 @@
 var Base = require('mocha/lib/reporters/base');
-var LoadsSocket = require('loads.js');
+var loads = require('loads.js');
 
 exports = module.exports = Loads;
 
 function Loads(runner) {
   Base.call(this, runner);
 
-  var address = process.env.LOADS_ZMQ_RECEIVER;
-  if (!address) {
+  var options = loads.getOptionsFromEnviron();
+  if (!options.receiver) {
     console.error('You need to set the value of LOADS_ZMQ_RECEIVER in order '
                 + 'to use the loads reporter.');
     return;
   }
-  var socket = new LoadsSocket();
+  var socket = new loads.LoadsSocket(options);
 
   runner.on('test', function(test){
     socket.send('startTest', {test: escape(test.title)});


### PR DESCRIPTION
I think it would be useful to have a generic test-runner that can be used without mocha.  This is a super-basic version, you just give it the name of a module and it executes each method on that module in turn.

(I also changed the LoadsSocket class to use an options hash rather than a list of parameters, this seems to be more in keeping with standard javascript practice when there more than one or two args).
